### PR TITLE
pull: add an option to specify the "json" type

### DIFF
--- a/packages/@imgcook/cli/bin/imgcook.js
+++ b/packages/@imgcook/cli/bin/imgcook.js
@@ -53,6 +53,11 @@ program
     '-a, --app',
     'Pull module into `mod` folder while your are in imgcook app project'
   )
+  .option(
+    '-o, --output <type>',
+    'The output type, available values are: source and json',
+    'source'
+  )
   .allowUnknownOption()
   .action(async (value, cmd) => {
     require('../lib/pull')(value, cmd);

--- a/packages/@imgcook/cli/lib/pull.js
+++ b/packages/@imgcook/cli/lib/pull.js
@@ -61,7 +61,14 @@ const pull = async (value, option) => {
     // );
     const moduleData = data.moduleData;
     let errorData;
-    moduleData && spinner.start(`「${moduleData.name}」Downloading module...`);
+    if (!moduleData) {
+      return spinner.fail(`failed to parse module data, moduleData not found.`);
+    }
+    if (option.output === 'json') {
+      process.stdout.write(moduleData.json);
+      return;
+    }
+    spinner.start(`「${moduleData.name}」Downloading module...`);
 
     try {
       // execute plugin

--- a/packages/@imgcook/cli/package.json
+++ b/packages/@imgcook/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imgcook/cli",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This adds an option(`--output`) to specify the "json" type which does pull the imgcook schema instead of generated code. BTW, this added a check when `moduleData` doesn't exist as well.